### PR TITLE
Add React POS skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# Restaurante
+# Restaurant POS Skeleton
+
+This is a minimal scaffold for a Restaurant Point of Sale web app built with React and Vite.
+
+## Setup
+
+```bash
+npm i
+npm run dev
+```
+
+## Build
+
+```bash
+npm run build
+npm run preview
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Restaurant POS</title>
+  </head>
+  <body class="bg-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "restaurant-pos",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint 'src/**/*.{ts,tsx}'",
+    "format": "prettier --write 'src/**/*.{ts,tsx,css}'"
+  },
+  "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.5.1",
+    "@fortawesome/free-solid-svg-icons": "^6.5.1",
+    "@fortawesome/react-fontawesome": "^0.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.16.0",
+    "zustand": "^4.3.9"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.24",
+    "@types/react-dom": "^18.2.9",
+    "@typescript-eslint/eslint-plugin": "^6.12.0",
+    "@typescript-eslint/parser": "^6.12.0",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8.54.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.33.2",
+    "postcss": "^8.4.31",
+    "prettier": "^3.1.0",
+    "tailwindcss": "^3.3.5",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,12 @@
+import { BrowserRouter } from 'react-router-dom';
+import Routes from '@routes/index';
+
+function App() {
+  return (
+    <BrowserRouter>
+      <Routes />
+    </BrowserRouter>
+  );
+}
+
+export default App;

--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -1,0 +1,16 @@
+interface Props {
+  label: string;
+  onClick: () => void;
+  className?: string;
+}
+
+export default function CTAButton({ label, onClick, className }: Props) {
+  return (
+    <button
+      onClick={onClick}
+      className={`rounded-lg bg-brand px-3 py-2 text-white shadow ${className || ''}`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/components/CategoryChip.tsx
+++ b/src/components/CategoryChip.tsx
@@ -1,0 +1,12 @@
+interface Props {
+  name: string;
+  count: number;
+}
+
+export default function CategoryChip({ name, count }: Props) {
+  return (
+    <button className="whitespace-nowrap rounded-full bg-brand px-3 py-1 text-white">
+      {name} ({count})
+    </button>
+  );
+}

--- a/src/components/MenuCard.tsx
+++ b/src/components/MenuCard.tsx
@@ -1,0 +1,30 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTags } from '@fortawesome/free-solid-svg-icons';
+import CTAButton from './CTAButton';
+
+interface Item {
+  id: number;
+  name: string;
+  price: number;
+  img: string;
+  isVeg: boolean;
+  hasDiscount: boolean;
+}
+
+interface Props {
+  item: Item;
+}
+
+export default function MenuCard({ item }: Props) {
+  return (
+    <div className="flex flex-col gap-2 rounded-xl bg-white/90 p-4 shadow-lg backdrop-blur">
+      <div className="relative h-24 rounded-md bg-gray-200" />
+      <div className="flex items-center justify-between">
+        <span className="font-medium">{item.name}</span>
+        {item.hasDiscount && <FontAwesomeIcon icon={faTags} className="text-brand" />}
+      </div>
+      <div className="text-sm text-gray-500">${item.price.toFixed(2)}</div>
+      <CTAButton label="Add" onClick={() => {}} />
+    </div>
+  );
+}

--- a/src/components/OrderList.tsx
+++ b/src/components/OrderList.tsx
@@ -1,0 +1,30 @@
+import { useCartStore } from '@store/useCartStore';
+import QuantityStepper from './QuantityStepper';
+
+export default function OrderList() {
+  const { items, updateQty, removeItem, getTotal, getTax } = useCartStore();
+
+  const total = getTotal();
+  const tax = getTax();
+
+  return (
+    <div className="flex flex-1 flex-col gap-2 overflow-y-auto rounded-xl bg-white/90 p-4 shadow-lg backdrop-blur">
+      {items.map((item) => (
+        <div key={item.id} className="flex items-center justify-between gap-2">
+          <span className="flex-1">{item.name}</span>
+          <QuantityStepper qty={item.qty} onChange={(q) => updateQty(item.id, q)} />
+          <span className="w-12 text-right text-sm">${(item.price * item.qty).toFixed(2)}</span>
+          <button onClick={() => removeItem(item.id)}>x</button>
+        </div>
+      ))}
+      <div className="mt-auto flex justify-between pt-2 text-sm">
+        <span>Tax:</span>
+        <span>${tax.toFixed(2)}</span>
+      </div>
+      <div className="flex justify-between font-semibold">
+        <span>Total:</span>
+        <span>${total.toFixed(2)}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/PaymentButtons.tsx
+++ b/src/components/PaymentButtons.tsx
@@ -1,0 +1,10 @@
+import CTAButton from './CTAButton';
+
+export default function PaymentButtons() {
+  return (
+    <div className="flex gap-2">
+      <CTAButton label="Pay Cash" onClick={() => {}} className="flex-1" />
+      <CTAButton label="Pay Card" onClick={() => {}} className="flex-1" />
+    </div>
+  );
+}

--- a/src/components/QuantityStepper.tsx
+++ b/src/components/QuantityStepper.tsx
@@ -1,0 +1,21 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPlus, faMinus } from '@fortawesome/free-solid-svg-icons';
+
+interface Props {
+  qty: number;
+  onChange: (qty: number) => void;
+}
+
+export default function QuantityStepper({ qty, onChange }: Props) {
+  return (
+    <div className="flex items-center gap-2">
+      <button className="rounded-full bg-brand p-1 text-white" onClick={() => onChange(qty - 1)}>
+        <FontAwesomeIcon icon={faMinus} />
+      </button>
+      <span>{qty}</span>
+      <button className="rounded-full bg-brand p-1 text-white" onClick={() => onChange(qty + 1)}>
+        <FontAwesomeIcon icon={faPlus} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,37 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faUtensils,
+  faChair,
+  faCalendarCheck,
+  faTruck,
+  faFileInvoiceDollar,
+  faCog
+} from '@fortawesome/free-solid-svg-icons';
+
+const links = [
+  { icon: faUtensils, label: 'Menu' },
+  { icon: faChair, label: 'Table Service' },
+  { icon: faCalendarCheck, label: 'Reservation' },
+  { icon: faTruck, label: 'Delivery' },
+  { icon: faFileInvoiceDollar, label: 'Accounting' },
+  { icon: faCog, label: 'Settings' }
+];
+
+export default function Sidebar() {
+  return (
+    <aside className="hidden w-64 flex-col bg-white/90 p-4 backdrop-blur md:flex">
+      <h1 className="mb-6 text-2xl font-bold text-brand">POS</h1>
+      <nav className="flex flex-col gap-4">
+        {links.map((l) => (
+          <button
+            key={l.label}
+            className="flex items-center gap-3 rounded-lg p-2 hover:bg-brand hover:text-white"
+          >
+            <FontAwesomeIcon icon={l.icon} />
+            {l.label}
+          </button>
+        ))}
+      </nav>
+    </aside>
+  );
+}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,0 +1,7 @@
+export default function TopBar() {
+  return (
+    <header className="flex items-center justify-between bg-white/90 p-4 backdrop-blur md:hidden">
+      <div className="text-lg font-bold text-brand">POS</div>
+    </header>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply text-gray-800;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/pages/PosDashboard.tsx
+++ b/src/pages/PosDashboard.tsx
@@ -1,0 +1,56 @@
+import Sidebar from '@components/Sidebar';
+import TopBar from '@components/TopBar';
+import CategoryChip from '@components/CategoryChip';
+import MenuCard from '@components/MenuCard';
+import OrderList from '@components/OrderList';
+import PaymentButtons from '@components/PaymentButtons';
+
+const categories = [
+  { id: 1, name: 'Breakfast', count: 4 },
+  { id: 2, name: 'Lunch', count: 8 },
+  { id: 3, name: 'Dinner', count: 5 },
+  { id: 4, name: 'Dessert', count: 6 },
+  { id: 5, name: 'Drinks', count: 7 },
+  { id: 6, name: 'Specials', count: 3 }
+];
+
+const menuItems = [
+  { id: 1, name: 'Item 1', price: 9.99, img: '', isVeg: true, hasDiscount: false },
+  { id: 2, name: 'Item 2', price: 5.99, img: '', isVeg: false, hasDiscount: true },
+  { id: 3, name: 'Item 3', price: 7.49, img: '', isVeg: true, hasDiscount: false },
+  { id: 4, name: 'Item 4', price: 11.5, img: '', isVeg: false, hasDiscount: false },
+  { id: 5, name: 'Item 5', price: 6.25, img: '', isVeg: true, hasDiscount: true },
+  { id: 6, name: 'Item 6', price: 8.0, img: '', isVeg: false, hasDiscount: false },
+  { id: 7, name: 'Item 7', price: 4.75, img: '', isVeg: true, hasDiscount: false },
+  { id: 8, name: 'Item 8', price: 9.0, img: '', isVeg: false, hasDiscount: false },
+  { id: 9, name: 'Item 9', price: 3.5, img: '', isVeg: true, hasDiscount: false }
+];
+
+export default function PosDashboard() {
+  return (
+    <div className="flex h-screen">
+      <Sidebar />
+      <div className="flex flex-1 flex-col">
+        <TopBar />
+        <div className="flex flex-1 overflow-hidden p-4">
+          <div className="flex flex-1 flex-col gap-4 overflow-y-auto">
+            <div className="flex gap-2 overflow-x-auto pb-2">
+              {categories.map((c) => (
+                <CategoryChip key={c.id} name={c.name} count={c.count} />
+              ))}
+            </div>
+            <div className="grid flex-1 grid-cols-2 gap-6 md:grid-cols-3 lg:grid-cols-4">
+              {menuItems.map((m) => (
+                <MenuCard key={m.id} item={m} />
+              ))}
+            </div>
+          </div>
+          <div className="hidden w-80 flex-col gap-4 pl-4 md:flex">
+            <OrderList />
+            <PaymentButtons />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,0 +1,10 @@
+import { Route, Routes } from 'react-router-dom';
+import PosDashboard from '@pages/PosDashboard';
+
+export default function AppRoutes() {
+  return (
+    <Routes>
+      <Route path="/" element={<PosDashboard />} />
+    </Routes>
+  );
+}

--- a/src/store/useCartStore.ts
+++ b/src/store/useCartStore.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+
+interface CartItem {
+  id: number;
+  name: string;
+  price: number;
+  qty: number;
+}
+
+interface CartState {
+  items: CartItem[];
+  addItem: (item: CartItem) => void;
+  removeItem: (id: number) => void;
+  updateQty: (id: number, qty: number) => void;
+  clear: () => void;
+  getTotal: () => number;
+  getTax: () => number;
+}
+
+export const useCartStore = create<CartState>((set, get) => ({
+  items: [],
+  addItem: (item) => set((state) => ({ items: [...state.items, item] })),
+  removeItem: (id) => set((state) => ({ items: state.items.filter((i) => i.id !== id) })),
+  updateQty: (id, qty) =>
+    set((state) => ({ items: state.items.map((i) => (i.id === id ? { ...i, qty } : i)) })),
+  clear: () => set({ items: [] }),
+  getTotal: () => get().items.reduce((sum, i) => sum + i.price * i.qty, 0),
+  getTax: () => get().getTotal() * 0.05
+}));

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        brand: '#00C072'
+      }
+    }
+  },
+  plugins: []
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "useDefineForClassFields": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "baseUrl": "./src",
+    "paths": {
+      "@components/*": ["components/*"],
+      "@pages/*": ["pages/*"],
+      "@assets/*": ["assets/*"],
+      "@store/*": ["store/*"],
+      "@routes/*": ["routes/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [{"path": "./tsconfig.node.json"}]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@components': path.resolve(__dirname, 'src/components'),
+      '@pages': path.resolve(__dirname, 'src/pages'),
+      '@assets': path.resolve(__dirname, 'src/assets'),
+      '@store': path.resolve(__dirname, 'src/store'),
+      '@routes': path.resolve(__dirname, 'src/routes')
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- initialize Vite React app with TailwindCSS, FontAwesome, Router and Zustand
- implement cart store and dashboard layout components
- add sample data and placeholder UI
- configure TypeScript paths and Tailwind brand color
- document setup and build steps

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_686830646fc08326ad2882a52e94ef5a